### PR TITLE
README : add winget install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ $ age --decrypt -i key.txt data.tar.gz.age > data.tar.gz
             <code>scoop bucket add extras; scoop install age</code>
         </td>
     </tr>
+    <tr>
+        <td>Winget (Windows)</td>
+        <td>
+            <code>winget install FiloSottile.age</code>
+        </td>
+    </tr>
 </table>
 
 On Windows, Linux, macOS, and FreeBSD you can use the pre-built binaries.


### PR DESCRIPTION
I noticed that winget is not listed as an installation method in README, even though it is available. It is such a trivial change that i took the liberty to create this PR without opening an issue about it.
If it is not desirable because it was a deliberate choice/winget is not a recommanded installation method, i would be interested to learn why, as i plan to use it.